### PR TITLE
 Added margin to video as well as padding to section headings 

### DIFF
--- a/css/override.css
+++ b/css/override.css
@@ -14,9 +14,9 @@ div.intro-content {
 ul.timeline li div.timeline-image {
     background-color: #fff;
 }
-.about_video{
-    margin: 0 0 100px 0;
+.about-video{
+    margin: 0 0 5.5rem 0;
 }
 .section-heading{
-  padding-bottom: 50px;
+  padding-bottom: 3rem;
 }

--- a/css/override.css
+++ b/css/override.css
@@ -14,3 +14,9 @@ div.intro-content {
 ul.timeline li div.timeline-image {
     background-color: #fff;
 }
+.about_video{
+    margin: 0 0 100px 0;
+}
+.section-heading{
+  padding-bottom: 50px;
+}

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
             <h2 class="section-heading text-uppercase">See it in action now</h2>
           </div>
         </div>
-        <div class="embed-responsive embed-responsive-16by9" style="padding: 30px ">
+        <div class="embed-responsive embed-responsive-16by9 about_video">
           <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/GM4UttTA80I" allowfullscreen></iframe>
         </div>
         <div class="row text-center">

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
             <h2 class="section-heading text-uppercase">See it in action now</h2>
           </div>
         </div>
-        <div class="embed-responsive embed-responsive-16by9">
+        <div class="embed-responsive embed-responsive-16by9" style="padding: 30px ">
           <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/GM4UttTA80I" allowfullscreen></iframe>
         </div>
         <div class="row text-center">
@@ -504,4 +504,3 @@
   </body>
 
 </html>
-

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
             <h2 class="section-heading text-uppercase">See it in action now</h2>
           </div>
         </div>
-        <div class="embed-responsive embed-responsive-16by9 about_video">
+        <div class="embed-responsive embed-responsive-16by9 about-video">
           <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/GM4UttTA80I" allowfullscreen></iframe>
         </div>
         <div class="row text-center">


### PR DESCRIPTION
The youtube video was too closely spaced to the elements beneath it, so i added some margin to the bottom.
The section headings were lacking a proper spacing, so I added some padding to them.

I've attached the screenshots for the same (Left side browser is the current version; Right side is the one after I made changes)
:)

![screenshot 237](https://user-images.githubusercontent.com/15854670/47843943-29024a80-dde7-11e8-867d-9393125af800.png)
![screenshot 238](https://user-images.githubusercontent.com/15854670/47843946-29024a80-dde7-11e8-8549-dae7ba3a3005.png)
![screenshot 239](https://user-images.githubusercontent.com/15854670/47843948-299ae100-dde7-11e8-8eba-3d68c2f6b0cb.png)
![screenshot 240](https://user-images.githubusercontent.com/15854670/47843950-299ae100-dde7-11e8-981b-906fd5588309.png)
